### PR TITLE
Added configurable solid fuel ticks in the firebox for the Steam Boiler

### DIFF
--- a/src/main/java/cassiokf/industrialrenewal/config/IRConfig.java
+++ b/src/main/java/cassiokf/industrialrenewal/config/IRConfig.java
@@ -212,8 +212,8 @@ public class IRConfig
             @Config.LangKey("gui.config.steam_factor.name")
             public int steamBoilerConversionFactor = 5;
 			
-			@Config.Comment("How many solid fuel ticks should be used for one firebox tick, ex: coal with 1600 / 2 is 800 ticks in the boiler (Default 2)")
-			public int solidFuelperFireboxTick = 2;
+	    @Config.Comment("How many solid fuel ticks should be used for one firebox tick, ex: coal with 1600 / 2 is 800 ticks in the boiler (Default 2)")
+	    public int solidFuelperFireboxTick = 2;
 
             @Config.Comment("How much steam the Steam Turbine need to rotate (Default 250)")
             public int steamTurbineSteamPerTick = 250;

--- a/src/main/java/cassiokf/industrialrenewal/config/IRConfig.java
+++ b/src/main/java/cassiokf/industrialrenewal/config/IRConfig.java
@@ -211,6 +211,9 @@ public class IRConfig
             @Config.Comment("The factor steam will be generated 1 Water : 5 Steam ex: 76 water/tick * 5 is 380 steam/tick per boiler (Default 5)")
             @Config.LangKey("gui.config.steam_factor.name")
             public int steamBoilerConversionFactor = 5;
+			
+			@Config.Comment("How many solid fuel ticks should be used for one firebox tick, ex: coal with 1600 / 2 is 800 ticks in the boiler (Default 2)")
+			public int solidFuelperFireboxTick = 2;
 
             @Config.Comment("How much steam the Steam Turbine need to rotate (Default 250)")
             public int steamTurbineSteamPerTick = 250;

--- a/src/main/java/cassiokf/industrialrenewal/tileentity/TileEntitySteamBoiler.java
+++ b/src/main/java/cassiokf/industrialrenewal/tileentity/TileEntitySteamBoiler.java
@@ -5,6 +5,7 @@ import cassiokf.industrialrenewal.handlers.SteamBoiler;
 import cassiokf.industrialrenewal.init.ModItems;
 import cassiokf.industrialrenewal.tileentity.abstracts.TileEntityMultiBlockBase;
 import cassiokf.industrialrenewal.util.Utils;
+import cassiokf.industrialrenewal.config.IRConfig;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -19,7 +20,7 @@ import javax.annotation.Nullable;
 public class TileEntitySteamBoiler extends TileEntityMultiBlockBase<TileEntitySteamBoiler>
 {
     private int type;
-    private static final int solidPerTick = 2;
+    private static final int solidPerTick = IRConfig.MainConfig.Main.solidFuelperFireboxTick;
     public final SteamBoiler boiler = new SteamBoiler(this, SteamBoiler.BoilerType.Solid, solidPerTick);
     private static final int fluidPerTick = 1;
 


### PR DESCRIPTION
This is so that it can consume solid fuel faster or slower depending on what's defined in the config, which is useful for modpacks with different boilers, did initially a small spacing issue in the config code which was fixed in an additional commit.