### PR TITLE
Fixed incorrect clamping formula

### DIFF
--- a/src/main/java/cassiokf/industrialrenewal/util/Utils.java
+++ b/src/main/java/cassiokf/industrialrenewal/util/Utils.java
@@ -233,7 +233,7 @@ public class Utils
 
     public static float normalizeClamped(float value, float min, float max)
     {
-        return MathHelper.clamp(0, (value - min), (max - min)) / (max - min);
+        return MathHelper.clamp((value - min), 0, (max - min)) / (max - min);
     }
 
     public static int getDistancePointToPoint(BlockPos pos1, BlockPos pos2)

--- a/src/main/java/cassiokf/industrialrenewal/util/Utils.java
+++ b/src/main/java/cassiokf/industrialrenewal/util/Utils.java
@@ -233,7 +233,7 @@ public class Utils
 
     public static float normalizeClamped(float value, float min, float max)
     {
-        return MathHelper.clamp((value - min) / (max - min), min, max);
+        return MathHelper.clamp(0, (value - min), (max - min)) / (max - min);
     }
 
     public static int getDistancePointToPoint(BlockPos pos1, BlockPos pos2)


### PR DESCRIPTION
This should clamp values between 0 when the value is less or equal than the min value, and 1 when the value is more or equal than the max value. Noticed that something was wrong with the steam boiler when it produced thousands of mb of steam per tick because the factor was over 1000, caused by incorrect placement of the division symbol in the clamping formula.