### PR TITLE
Bug fix for Boiler fuel update issue

### DIFF
--- a/src/main/java/cassiokf/industrialrenewal/handlers/SteamBoiler.java
+++ b/src/main/java/cassiokf/industrialrenewal/handlers/SteamBoiler.java
@@ -256,6 +256,10 @@ public class SteamBoiler
             heat += 8;
             fuelTime -= amountPerTick;
         }
+		else if (fuelTime < amountPerTick && fuelTime > 0)
+		{
+			resetFuelTime();
+		}
         else heat -= 2;
     }
 

--- a/src/main/java/cassiokf/industrialrenewal/handlers/SteamBoiler.java
+++ b/src/main/java/cassiokf/industrialrenewal/handlers/SteamBoiler.java
@@ -231,7 +231,7 @@ public class SteamBoiler
 
     private ItemStack updateSolidFuel(ItemStack stack, boolean simulate)
     {
-        if (!useSolid || fuelTime > 0) return stack;
+        if (!useSolid || fuelTime >= amountPerTick) return stack;
         int fuel = TileEntityFurnace.getItemBurnTime(stack);
         if (fuel > 0)
         {


### PR DESCRIPTION
In some cases, such as certain mods which modifies burnable fuels, the fuelTime variable could be above 0 but below the required amountPerTick, and in that case the boiler thinks it doesn't need another fuel piece, which would cause it to cool itself down, unable to pull another fuel item. This tiny fix would be a workaround for those scenarios.